### PR TITLE
Fix GIF generation workflow detection logic

### DIFF
--- a/.github/workflows/generate-gif-manual.yml
+++ b/.github/workflows/generate-gif-manual.yml
@@ -9,17 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Check for changes in src folder
-        id: check_changes
-        run: |
-          if git diff --quiet HEAD -- src/; then
-            echo "CHANGED=false" >> $GITHUB_ENV
-          else
-            echo "CHANGED=true" >> $GITHUB_ENV
-          fi
-
       - name: Generate GIF from Website
-        if: env.CHANGED == 'true'
         uses: PabloLec/website-to-gif@2.1.1
         with:
           url: "https://mrtysn.github.io/cv/"
@@ -35,7 +25,6 @@ jobs:
           start_delay: 4000
 
       - name: Compress GIF with gifsicle
-        if: env.CHANGED == 'true'
         run: |
           echo "📊 Original file size:"
           du -h cv-preview.gif
@@ -56,7 +45,6 @@ jobs:
           du -h cv-preview.gif
 
       - name: Commit GIF to the Repository
-        if: env.CHANGED == 'true'
         id: commit
         run: |
           git config --global user.name "${{ github.actor }}"

--- a/.github/workflows/generate-gif.yml
+++ b/.github/workflows/generate-gif.yml
@@ -10,11 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2  # Required to access HEAD^ (previous commit)
 
       - name: Check for changes in src folder
         id: check_changes
         run: |
-          if git diff --quiet HEAD -- src/; then
+          if git diff --quiet HEAD^ HEAD -- src/; then
             echo "CHANGED=false" >> $GITHUB_ENV
           else
             echo "CHANGED=true" >> $GITHUB_ENV


### PR DESCRIPTION
- Automatic workflow: Restore HEAD^ HEAD comparison to detect src/ changes between commits
- Automatic workflow: Add fetch-depth: 2 to checkout step for HEAD^ access
- Manual workflow: Remove all conditionals to always run when manually triggered

This fixes the issue introduced in commit 9cbd174 where HEAD^ was removed, causing the workflow to never detect changes in CI environment.